### PR TITLE
fix: correct 'sucesfully' to 'successfully' typo in symlink creation message

### DIFF
--- a/build/link.ts
+++ b/build/link.ts
@@ -42,4 +42,4 @@ try {
     process.exit(1);
 }
 
-console.log(`Symlink sucesfully created at "${symlinkPath}"!`);
+console.log(`Symlink successfully created at "${symlinkPath}"!`);


### PR DESCRIPTION
## Summary
Fix `sucesfully` → `successfully` typo in symlink creation console message.

## File changed
- `build/link.ts` line 45: `Symlink sucesfully created` → `Symlink successfully created`